### PR TITLE
Integrate sbt-apache-sonatype and remove ci-release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ ThisBuild / resolvers ++= {
   else Seq.empty
 }
 
+ThisBuild / apacheSonatypeProjectProfile := "pekko"
+
 // make version compatible with docker for publishing example project
 ThisBuild / dynverSeparator := "-"
 
@@ -22,7 +24,6 @@ dumpSchema := (core / Test / runMain).toTask(" akka.persistence.cassandra.PrintC
 lazy val core = project
   .in(file("core"))
   .enablePlugins(Common, AutomateHeaderPlugin, MultiJvmPlugin)
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .dependsOn(cassandraLauncher % Test)
   .settings(
     name := "pekko-persistence-cassandra",
@@ -34,7 +35,6 @@ lazy val core = project
 lazy val cassandraLauncher = project
   .in(file("cassandra-launcher"))
   .enablePlugins(Common)
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .settings(
     name := "pekko-persistence-cassandra-launcher",
     Compile / managedResourceDirectories += (cassandraBundle / target).value / "bundle",
@@ -45,7 +45,6 @@ lazy val cassandraLauncher = project
 lazy val cassandraBundle = project
   .in(file("cassandra-bundle"))
   .enablePlugins(Common, AutomateHeaderPlugin)
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .settings(
     name := "pekko-persistence-cassandra-bundle",
     crossPaths := false,
@@ -60,7 +59,6 @@ lazy val cassandraBundle = project
 lazy val endToEndExample = project
   .in(file("example"))
   .dependsOn(core)
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .settings(libraryDependencies ++= Dependencies.exampleDependencies, publish / skip := true)
   .settings(
     dockerBaseImage := "openjdk:8-jre-alpine",
@@ -92,7 +90,6 @@ lazy val endToEndExample = project
 
 lazy val dseTest = project
   .in(file("dse-test"))
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .dependsOn(core % "test->test")
   .settings(libraryDependencies ++= Dependencies.dseTestDependencies)
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -9,23 +9,22 @@
 
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys._
 import de.heikoseeberger.sbtheader._
+import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport._
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
-import xerial.sbt.Sonatype.autoImport.sonatypeProfileName
+import sbtdynver.DynVerPlugin
+import sbtdynver.DynVerPlugin.autoImport.dynverSonatypeSnapshots
 
 object Common extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def requires = JvmPlugin && HeaderPlugin
+  override def requires = JvmPlugin && HeaderPlugin && SonatypeApachePlugin && DynVerPlugin
 
   override def globalSettings =
     Seq(
-      organization := "org.apache.pekko",
-      organizationName := "Apache Software Foundation",
-      organizationHomepage := Some(url("https://pekko.apache.org/")),
       startYear := Some(2016),
       homepage := Some(url("https://pekko.apache.org/")),
       // apiURL defined in projectSettings because version.value is not correct here
@@ -38,7 +37,6 @@ object Common extends AutoPlugin {
         "Contributors",
         "dev@pekko.apache.org",
         url("https://github.com/apache/incubator-pekko-persistence-cassandra/graphs/contributors")),
-      licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
       description := "A Cassandra plugin for Apache Pekko Persistence.")
 
   override lazy val projectSettings = Seq(
@@ -67,7 +65,6 @@ object Common extends AutoPlugin {
     Compile / doc / scalacOptions --= Seq("-Xfatal-warnings"),
     scalafmtOnCompile := true,
     autoAPIMappings := true,
-    sonatypeProfileName := "org.apache.pekko",
     Test / logBuffered := System.getProperty("pekko.logBufferedTests", "false").toBoolean,
     // show full stack traces and test case durations
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
@@ -76,4 +73,7 @@ object Common extends AutoPlugin {
     // -q Suppress stdout for successful tests.
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-q"),
     Test / parallelExecution := false)
+
+  override lazy val buildSettings = Seq(
+    dynverSonatypeSnapshots := true)
 }

--- a/project/MetaInfLicenseNoticeCopy.scala
+++ b/project/MetaInfLicenseNoticeCopy.scala
@@ -7,26 +7,21 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
+import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
+import org.mdedetrich.apache.sonatype.SonatypeApachePlugin.autoImport.apacheSonatypeDisclaimerFile
+import sbt._
 import sbt.Keys._
-import sbt.{ Def, _ }
 
 /**
  * Copies LICENSE and NOTICE files into jar META-INF dir
  */
-object MetaInfLicenseNoticeCopy {
+object MetaInfLicenseNoticeCopy extends AutoPlugin {
 
-  val settings: Seq[Setting[_]] = inConfig(Compile)(
-    Seq(
-      resourceGenerators += copyFileToMetaInf(resourceManaged, "LICENSE"),
-      resourceGenerators += copyFileToMetaInf(resourceManaged, "NOTICE"),
-      resourceGenerators += copyFileToMetaInf(resourceManaged, "DISCLAIMER")))
+  override def trigger = allRequirements
 
-  def copyFileToMetaInf(dir: SettingKey[File], fileName: String): Def.Initialize[Task[Seq[sbt.File]]] =
-    Def.task[Seq[File]] {
-      val fromFile = (LocalRootProject / baseDirectory).value / fileName
-      val toFile = resourceManaged.value / "META-INF" / fileName
-      IO.copyFile(fromFile, toFile)
-      Seq(toFile)
-    }
+  override def requires = SonatypeApachePlugin
+
+  override lazy val projectSettings = Seq(
+    apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.6")
 
 // Documentation
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.42")


### PR DESCRIPTION
This PR

* Replaces ci-release with dynver (see https://lists.apache.org/thread/l7yp8yb2ooy7opwmzpw7hkmz9gm0qr2r)
* Integrates sbt-apache-sonatype to handle both publishing and copying of license files