### PR TITLE
Update sbt-apache-sonatype and handle rename

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -9,7 +9,7 @@
 
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys._
 import de.heikoseeberger.sbtheader._
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
@@ -20,7 +20,7 @@ object Common extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def requires = JvmPlugin && HeaderPlugin && SonatypeApachePlugin && DynVerPlugin
+  override def requires = JvmPlugin && HeaderPlugin && ApacheSonatypePlugin && DynVerPlugin
 
   override def globalSettings =
     Seq(

--- a/project/MetaInfLicenseNoticeCopy.scala
+++ b/project/MetaInfLicenseNoticeCopy.scala
@@ -7,8 +7,8 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin.autoImport.apacheSonatypeDisclaimerFile
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin.autoImport.apacheSonatypeDisclaimerFile
 import sbt._
 import sbt.Keys._
 
@@ -19,7 +19,7 @@ object MetaInfLicenseNoticeCopy extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def requires = SonatypeApachePlugin
+  override def requires = ApacheSonatypePlugin
 
   override lazy val projectSettings = Seq(
     apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.6")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.7")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
 
 // Documentation


### PR DESCRIPTION
Updates sbt-apache-sonatype. Note that this new version renames `SonatypeApachePlugin` to `ApacheSonatypePlugin` to be consistent with the project name.