### PR TITLE
Unwrap single string interpolation syntax

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/EventsByTagStage.scala
@@ -147,7 +147,7 @@ import scala.util.{ Failure, Success, Try }
     // don't include buffered in the toString
     override def toString =
       s"LookingForMissing{min=$minOffset maxOffset=$maxOffset bucket=$bucket " +
-      s"queryPrevious=$queryPrevious searchingFor=${remainingMissing} " +
+      s"queryPrevious=$queryPrevious searchingFor=$remainingMissing " +
       s"missing=$remainingMissing deadline=$deadline gapDetected=$gapDetected"
   }
 

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/MissingTaggedEventException.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/query/MissingTaggedEventException.scala
@@ -34,4 +34,4 @@ final class MissingTaggedEventException(
     val missing: Map[String, Set[Long]],
     val minOffset: UUID,
     val maxOffset: UUID)
-    extends RuntimeException(s"Unable to find tagged events for tag [$tag]: ${missing}")
+    extends RuntimeException(s"Unable to find tagged events for tag [$tag]: $missing")

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStatements.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/snapshot/CassandraSnapshotStatements.scala
@@ -40,7 +40,7 @@ import pekko.persistence.cassandra.FutureDone
   // snapshot is for backwards compatibility and not used for new rows
   def createTable =
     s"""
-    |CREATE TABLE IF NOT EXISTS ${tableName} (
+    |CREATE TABLE IF NOT EXISTS $tableName (
     |  persistence_id text,
     |  sequence_nr bigint,
     |  timestamp bigint,
@@ -57,19 +57,19 @@ import pekko.persistence.cassandra.FutureDone
     """.stripMargin.trim
 
   def writeSnapshot(withMeta: Boolean): String = s"""
-      INSERT INTO ${tableName} (persistence_id, sequence_nr, timestamp, ser_manifest, ser_id, snapshot_data
+      INSERT INTO $tableName (persistence_id, sequence_nr, timestamp, ser_manifest, ser_id, snapshot_data
       ${if (withMeta) ", meta_ser_id, meta_ser_manifest, meta" else ""})
       VALUES (?, ?, ?, ?, ?, ? ${if (withMeta) ", ?, ?, ?" else ""})
     """
 
   def deleteSnapshot = s"""
-      DELETE FROM ${tableName} WHERE
+      DELETE FROM $tableName WHERE
         persistence_id = ? AND
         sequence_nr = ?
     """
 
   def deleteAllSnapshotForPersistenceIdAndSequenceNrBetween = s"""
-    DELETE FROM ${tableName}
+    DELETE FROM $tableName
     WHERE persistence_id = ?
     AND sequence_nr >= ?
     AND sequence_nr <= ?
@@ -77,34 +77,34 @@ import pekko.persistence.cassandra.FutureDone
 
   def deleteSnapshotsBefore =
     s"""
-        DELETE FROM ${tableName}
+        DELETE FROM $tableName
         WHERE persistence_id = ?
         AND sequence_nr < ?
        """
 
   def selectSnapshot = s"""
-      SELECT * FROM ${tableName} WHERE
+      SELECT * FROM $tableName WHERE
         persistence_id = ? AND
         sequence_nr = ?
     """
 
   def selectSnapshotMetadata(limit: Option[Int] = None) = s"""
-      SELECT persistence_id, sequence_nr, timestamp FROM ${tableName} WHERE
+      SELECT persistence_id, sequence_nr, timestamp FROM $tableName WHERE
         persistence_id = ? AND
         sequence_nr <= ? AND
         sequence_nr >= ?
-        ${limit.map(l => s"LIMIT ${l}").getOrElse("")}
+        ${limit.map(l => s"LIMIT $l").getOrElse("")}
     """
 
   def selectLatestSnapshotMeta =
-    s"""SELECT persistence_id, sequence_nr, timestamp FROM ${tableName} WHERE
+    s"""SELECT persistence_id, sequence_nr, timestamp FROM $tableName WHERE
     persistence_id = ? 
     ORDER BY sequence_nr DESC
     LIMIT ?
     """
 
   def selectAllSnapshotMeta =
-    s"""SELECT sequence_nr, timestamp FROM ${tableName} WHERE
+    s"""SELECT sequence_nr, timestamp FROM $tableName WHERE
     persistence_id = ? 
     ORDER BY sequence_nr DESC
     """

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/CassandraSpec.scala
@@ -185,7 +185,7 @@ abstract class CassandraSpec(
         if (system.settings.config.getBoolean("pekko.persistence.cassandra.events-by-tag.enabled")) {
           println("tag_views")
           cluster
-            .execute(s"select * from ${journalName}.tag_views")
+            .execute(s"select * from $journalName.tag_views")
             .asScala
             .foreach(row => {
               println(s"""Row:${row.getString("tag_name")},${row.getLong("timebucket")},${formatOffset(

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -269,7 +269,7 @@ class EventsByTagMigrationSpec extends AbstractEventsByTagMigrationSpec {
     }
 
     "have a peek in the messages table" taggedAs RequiresCassandraThree in {
-      val row = cluster.execute(SimpleStatement.newInstance(s"select * from ${messagesTableName} limit 1")).one()
+      val row = cluster.execute(SimpleStatement.newInstance(s"select * from $messagesTableName limit 1")).one()
       system.log.debug("New messages table looks like: {}", row)
       system.log.debug("{}", row.getColumnDefinitions)
     }

--- a/core/src/test/scala/org/apache/pekko/persistence/cassandra/EventsByTagRecoverySpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/cassandra/EventsByTagRecoverySpec.scala
@@ -112,8 +112,8 @@ class EventsByTagRecoverySpec extends CassandraSpec(EventsByTagRecoverySpec.conf
 
         Thread.sleep(500)
         systemTwo.terminate().futureValue
-        cluster.execute(s"truncate ${journalName}.tag_views")
-        cluster.execute(s"truncate ${journalName}.tag_write_progress")
+        cluster.execute(s"truncate $journalName.tag_views")
+        cluster.execute(s"truncate $journalName.tag_write_progress")
 
         val tProbe = TestProbe()(system)
         val p2take2 = system.actorOf(TestTaggingActor.props("p2", Set("red", "orange")))
@@ -158,8 +158,8 @@ class EventsByTagRecoverySpec extends CassandraSpec(EventsByTagRecoverySpec.conf
         Thread.sleep(500)
 
         systemTwo.terminate().futureValue
-        cluster.execute(s"truncate ${journalName}.tag_views")
-        cluster.execute(s"truncate ${journalName}.tag_write_progress")
+        cluster.execute(s"truncate $journalName.tag_views")
+        cluster.execute(s"truncate $journalName.tag_write_progress")
 
         val tProbe = TestProbe()(system)
         val p3take2 = system.actorOf(TestTaggingActor.props("p3", Set("red", "orange")))

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -66,7 +66,7 @@ trait CopyrightHeader extends AutoPlugin {
         case Some(existedText) if isOnlyLightbendCopyrightAnnotated(existedText) =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText) + NewLine * 2 + existedText
         case Some(existedText) =>
-          throw new IllegalStateException(s"Unable to detect Copyright for header:[${existedText}]")
+          throw new IllegalStateException(s"Unable to detect Copyright for header:[$existedText]")
         case None =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText)
       }


### PR DESCRIPTION
Unwraps single string interpolation i.e. `s"${something}"` into `s"$something"`. Make sure to do a rebase merge of this PR because I need to add its commit to `.git-blame-ignore-revs`