### PR TITLE
uptake pekko 1.0.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val scala3Version = "3.1.2" // not yet enabled - missing pekko-http/pekko-management Scala 3 artifacts
   val scalaVersions = Seq(scala212Version, scala213Version)
 
-  val pekkoVersion = System.getProperty("override.pekko.version", "0.0.0+26669-ec5b6764-SNAPSHOT")
+  val pekkoVersion = System.getProperty("override.pekko.version", "1.0.0")
   val pekkoVersionInDocs = "current"
   val cassandraVersionInDocs = "4.0"
 
@@ -25,10 +25,10 @@ object Dependencies {
   val driverVersion = "4.15.0"
   val driverVersionInDocs = "4.14"
 
-  val pekkoConnectorsVersion = "0.0.0+123-178795f6-SNAPSHOT"
+  val pekkoConnectorsVersion = "0.0.0+131-79ec6fa6-SNAPSHOT"
   val pekkoConnectorsVersionInDocs = "current"
   // for example
-  val pekkoManagementVersion = "0.0.0+752-95cdd415-SNAPSHOT"
+  val pekkoManagementVersion = "0.0.0+757-f7d48cde-SNAPSHOT"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.10"
 


### PR DESCRIPTION
pekko snapshots for downstream modules need to be updated too to versions that were built with pekko 1.0.0 