### PR TITLE
Only override dynverSeparator for endToEndExample

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,6 @@ commands := commands.value.filterNot { command =>
   }
 }
 
-// make version compatible with docker for publishing example project
-ThisBuild / dynverSeparator := "-"
-
 lazy val root = project
   .in(file("."))
   .enablePlugins(Common, ScalaUnidocPlugin)
@@ -71,7 +68,11 @@ lazy val cassandraBundle = project
 lazy val endToEndExample = project
   .in(file("example"))
   .dependsOn(core)
-  .settings(libraryDependencies ++= Dependencies.exampleDependencies, publish / skip := true)
+  .settings(
+    libraryDependencies ++= Dependencies.exampleDependencies, publish / skip := true,
+    // make version compatible with docker for publishing example project,
+    // see https://github.com/sbt/sbt-dynver#portable-version-strings
+    inConfig(Docker)(DynVerPlugin.buildSettings ++ Seq(dynverSeparator := "-")))
   .settings(
     dockerBaseImage := "openjdk:8-jre-alpine",
     dockerCommands :=


### PR DESCRIPTION
We should only override this setting for the actual sbt sub project that creates a docker image otherwise our snapshots have non standard versioning.

Here is the output of sbt to demonstrate its working

```
sbt:pekko-persistence-cassandra-root> version
[info] core / version
[info]  0.0.0+1121-200a4509+20230906-1245-SNAPSHOT
[info] cassandraLauncher / version
[info]  0.0.0+1121-200a4509+20230906-1245-SNAPSHOT
[info] version
[info]  0.0.0+1121-200a4509+20230906-1245-SNAPSHOT
sbt:pekko-persistence-cassandra-root> endToEndExample/version
[info] 0.0.0-1121-200a4509-20230906-1245
sbt:pekko-persistence-cassandra-root> 
```

Note how version is normally `0.0.0+1121-200a4509+20230906-1245-SNAPSHOT` but in `endToEndExample` its `0.0.0-1121-200a4509-20230906-1245`