### PR TITLE
validate links in docs

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -1,0 +1,42 @@
+name: Link Validator
+
+permissions: {}
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  validate-links:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'apache/incubator-pekko-persistence-cassandra'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Setup Java 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Setup Coursier
+        uses: coursier/setup-action@v1.3.3
+
+      # assign an arbitrary version number so that scripts/link-validator.conf has a predictable set of links to work with
+      - name: Create the Pekko site
+        run: sbt "set ThisBuild / version := \"1.0.0\"; unidoc; docs/paradox"
+
+      - name: Run Link Validator
+        run: cs launch net.runne::site-link-validator:0.2.2 -- scripts/link-validator.conf

--- a/docs/src/main/paradox/migrations.md
+++ b/docs/src/main/paradox/migrations.md
@@ -2,7 +2,7 @@
 
 * Before migrating to Apache Pekko Persistence Cassandra, ensure that you have [migrated](https://doc.akka.io/docs/akka-persistence-cassandra/1.0.6/migrations.html) to akka-persistence-cassandra 1.0.6
 * The core [Pekko migration guide](https://pekko.apache.org/docs/pekko/current/project/migration-guides.html) is also worth reading.
-* Note that this project uses the `pekko` [keyspace](https://cassandra.apache.org/doc/latest/cassandra/data_modeling/data_modeling_schema.html) instead of `akka`.
+* Note that this project uses the `pekko` [keyspace](https://cassandra.apache.org/_/glossary.html#keyspace) instead of `akka`.
 
 ## Keyspaces
 As noted above the default keyspace has been changed. 

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -68,7 +68,7 @@ Gradle
 
 Snapshot builds are available at [https://repository.apache.org/content/groups/snapshots/org/apache/pekko/](https://repository.apache.org/content/groups/snapshots/org/apache/pekko/). All Pekko modules that belong to the same build have the same version.
 
-The [snapshot documentation](https://pekko.apache.org/docs/pekko-persistence-cassandra/snapshot/) is updated with every snapshot build.
+The [snapshot documentation](https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/main-snapshot/) is updated with every snapshot build.
 
 ## History
 

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -68,7 +68,7 @@ Gradle
 
 Snapshot builds are available at [https://repository.apache.org/content/groups/snapshots/org/apache/pekko/](https://repository.apache.org/content/groups/snapshots/org/apache/pekko/). All Pekko modules that belong to the same build have the same version.
 
-The [snapshot documentation](https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/main-snapshot/) is updated with every snapshot build.
+The [snapshot documentation](https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/main-snapshot/docs/) is updated with every snapshot build.
 
 ## History
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,19 +17,19 @@ object Dependencies {
   val scalaVersions = Seq(scala212Version, scala213Version, scala3Version)
 
   val pekkoVersion = System.getProperty("override.pekko.version", "1.0.1")
-  val pekkoVersionInDocs = "current"
+  val pekkoVersionInDocs = "1.0"
   val cassandraVersionInDocs = "4.0"
 
   // Should be sync with the version of the driver in Pekko Connectors Cassandra
   val driverVersion = "4.15.0"
   val driverVersionInDocs = "4.14"
 
-  val pekkoConnectorsVersion = "1.0.0"
-  val pekkoConnectorsVersionInDocs = "current"
+  val pekkoConnectorsVersion = "1.0.1"
+  val pekkoConnectorsVersionInDocs = "1.0"
   // for example
   val pekkoManagementVersion = "1.0.0"
 
-  val logback = "ch.qos.logback" % "logback-classic" % "1.2.10"
+  val logback = "ch.qos.logback" % "logback-classic" % "1.2.11"
 
   val reconcilerDependencies = Seq(
     "org.apache.pekko" %% "pekko-actor-testkit-typed" % pekkoVersion % Test,

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -29,6 +29,10 @@ site-link-validator {
       prefix = "https://pekko.apache.org/api/pekko-persistence-cassandra/snapshot/"
       replace = "/../../../../../target/scala-2.13/unidoc/"
     }
+    {
+      prefix = "https://pekko.apache.org/japi/pekko-persistence-cassandra/snapshot/"
+      replace = "/../../../../../target/scala-2.13/unidoc/"
+    }
   ]
 
   ignore-missing-local-files-regex = ""

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+
+// config for https://github.com/ennru/site-link-validator/
+site-link-validator {
+  root-dir = "docs/target/paradox/site/main/"
+  # relative to `root-dir`
+  start-file = "index.html"
+
+  # Resolves URLs with the given prefix as local files instead
+  link-mappings = [
+    {
+      prefix = "https://pekko.apache.org/docs/pekko-persistence-cassandra/1.0.0/"
+      replace = ""
+    }
+    {
+      prefix = "https://pekko.apache.org/docs/pekko-persistence-cassandra/current/"
+      replace = ""
+    }
+    # ScalaDoc from unidoc
+    {
+      prefix = "https://pekko.apache.org/api/pekko-persistence-cassandra/1.0.0/"
+      replace = "/../../../../../target/scala-2.13/unidoc/"
+    }
+    {
+      prefix = "https://pekko.apache.org/api/pekko-persistence-cassandra/current/"
+      replace = "/../../../../../target/scala-2.13/unidoc/"
+    }
+    {
+      prefix = "https://pekko.apache.org/api/pekko-persistence-cassandra/snapshot/"
+      replace = "/../../../../../target/scala-2.13/unidoc/"
+    }
+  ]
+
+  ignore-missing-local-files-regex = ""
+  // e.g. "^api/alpakka/snapshot/pekko/stream/alpakka/googlecloud/storage/impl/Formats.*"
+
+  ignore-prefixes = [
+    # Fails after a number of requests with "403 Forbidden"
+    "https://javadoc.io/static/"
+    # GitHub will block with "429 Too Many Requests"
+    "https://github.com/"
+  ]
+
+  non-https-whitelist = [
+  ]
+}

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -30,8 +30,8 @@ site-link-validator {
       replace = "/../../../../../target/scala-2.13/unidoc/"
     }
     {
-      prefix = "https://pekko.apache.org/japi/pekko-persistence-cassandra/snapshot/"
-      replace = "/../../../../../target/scala-2.13/unidoc/"
+      prefix = "https://pekko.apache.org/japi/pekko-persistence-cassandra/snapshot"
+      replace = "/../../../../../target/scala-2.13/unidoc"
     }
   ]
 


### PR DESCRIPTION
job is failing due to bad scaladoc links for pekko-connectors - package name is partially repeated in the links

```
## HTTP failure response
`[https://pekko.apache.org/api/pekko-connectors/1.0.0/org/apache/pekko/stream/connectors/org/apache/pekko/stream/connectors/cassandra/javadsl/CassandraSession.html`](https://pekko.apache.org/api/pekko-connectors/1.0.0/org/apache/pekko/stream/connectors/org/apache/pekko/stream/connectors/cassandra/javadsl/CassandraSession.html%60) status 404 Not Found
 - ../../../../../target/scala-2.13/unidoc/org/apache/pekko/persistence/cassandra/query/javadsl/CassandraReadJournal.html

`[https://pekko.apache.org/api/pekko-connectors/1.0.0/org/apache/pekko/stream/connectors/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraSession.html`](https://pekko.apache.org/api/pekko-connectors/1.0.0/org/apache/pekko/stream/connectors/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraSession.html%60) status 404 Not Found
 - ../../../../../target/scala-2.13/unidoc/org/apache/pekko/persistence/cassandra/EventsByTagMigration.html
 - ../../../../../target/scala-2.13/unidoc/org/apache/pekko/persistence/cassandra/query/scaladsl/CassandraReadJournal.html
```