### PR TITLE
protect 1.0.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,6 +41,18 @@ github:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
         required_approving_review_count: 1
+    1.0.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
 
 notifications:
   commits:              commits@pekko.apache.org


### PR DESCRIPTION
we have a few PRs targeted at 1.1.0 release so it seems like a good time to fork 1.0.x branch and protect it