### PR TITLE
replace deprecated statefulMapConcat

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
@@ -39,10 +39,12 @@ private[pekko] final class AllTags(session: ReconciliationSession) {
       .selectAllTagProgress()
       .map(_.getString("tag"))
       .statefulMap(() => mutable.Set.empty[String])(
-        (seen, tag) => {
-          val element = if (seen.contains(tag)) None else Some(tag)
-          (seen.+=(tag), element)
-        },
+        (seen, tag) =>
+          if (seen.contains(tag)) {
+            (seen, None)
+          } else {
+            (seen.+=(tag), Some(tag))
+          },
         _ => None)
       .collect { case Some(tag) => tag }
   }

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
@@ -40,7 +40,7 @@ private[pekko] final class AllTags(session: ReconciliationSession) {
         (seen, tag) => (seen + tag, None), seen => Some(Some(seen)))
       .flatMapConcat {
         case Some(seen) => Source(seen)
-        case None => Source.empty
+        case None       => Source.empty
       }
   }
 

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
@@ -41,7 +41,7 @@ private[pekko] final class AllTags(session: ReconciliationSession) {
       .statefulMap(() => mutable.Set.empty[String])(
         (seen, tag) => {
           val element = if (seen.contains(tag)) None else Some(tag)
-          (seen.addOne(tag), element)
+          (seen.+=(tag), element)
         },
         _ => None)
       .collect { case Some(tag) => tag }

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
@@ -18,6 +18,8 @@ import pekko.annotation.InternalApi
 import pekko.stream.scaladsl.Source
 import pekko.NotUsed
 
+import scala.collection.mutable
+
 /**
  * Calculates all the tags by scanning the tag_write_progress table.
  *
@@ -36,10 +38,10 @@ private[pekko] final class AllTags(session: ReconciliationSession) {
     session
       .selectAllTagProgress()
       .map(_.getString("tag"))
-      .statefulMap(() => Set.empty[String])(
+      .statefulMap(() => mutable.Set.empty[String])(
         (seen, tag) => {
           val element = if (seen.contains(tag)) None else Some(tag)
-          (seen + tag, element)
+          (seen.addOne(tag), element)
         },
         _ => None)
       .collect { case Some(tag) => tag }

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
@@ -18,6 +18,8 @@ import pekko.annotation.InternalApi
 import pekko.stream.scaladsl.Source
 import pekko.NotUsed
 
+import scala.collection.mutable
+
 /**
  * Calculates all the tags by scanning the tag_write_progress table.
  *
@@ -36,10 +38,10 @@ private[pekko] final class AllTags(session: ReconciliationSession) {
     session
       .selectAllTagProgress()
       .map(_.getString("tag"))
-      .statefulMap(() => Set.empty[String])(
+      .statefulMap(() => mutable.LinkedHashSet.empty[String])(
         (seen, tag) => (seen + tag, None), seen => Some(Some(seen)))
       .flatMapConcat {
-        case Some(seen) => Source(seen)
+        case Some(seen) => Source(seen.toSeq)
         case None       => Source.empty
       }
   }

--- a/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/cassandra/reconciler/AllTags.scala
@@ -43,7 +43,7 @@ private[pekko] final class AllTags(session: ReconciliationSession) {
           if (seen.contains(tag)) {
             (seen, None)
           } else {
-            (seen.+=(tag), Some(tag))
+            (seen += tag, Some(tag))
           },
         _ => None)
       .collect { case Some(tag) => tag }


### PR DESCRIPTION
I'm not sure if this is better but statefulMapConcat is deprecated.

The code is trying the take a Source[String, _] and to remove duplicates.

Both approaches involve building sets and those sets will consume a lot of memory if there is a lot of data. I don't think this is avoidable.

I am not a Cassandra expert but I think we might be able to get Cassandra to run 'DISTINCT' on the query. That could mean that we could remove the statefulMapConcat/statefulMap stage.