### PR TITLE
Update .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,10 +1,6 @@
-pullRequests.frequency = "@monthly"
-
 updates.ignore = [
   // explicit updates
   { groupId = "org.apache.pekko" }
 ]
 
-commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
-
-updatePullRequests = never
+updatePullRequests = "always"


### PR DESCRIPTION
(cherry picked from commit e50d8214cf06ee485670422986c1daaf32a454f5)

I know that this is not strictly necessary since we are not using scala steward in 1.0.x but its causing cherry pick merge conflicts with other PR's that I am trying to backport (such as https://github.com/apache/incubator-pekko-persistence-cassandra/pull/161)